### PR TITLE
Show the people to contact in a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ _[(English version)](README.en.md)_
 
 Лица за контакт:
 
-Радослав Миланов, имейл: rmilanov@government.bg; 
-
-Павел Иванов, имейл: p.ivanov@government.bg  
+- Радослав Миланов, имейл: rmilanov@government.bg
+- Павел Иванов, имейл: p.ivanov@government.bg
 
 ## Принос към проектите
 


### PR DESCRIPTION
С тази промяна предлагам лицата за контакт в README-то да се показват като списък с bullets, вместо просто на нов ред. Изглежда по-добре визуално и смислово е по-близо до идеята на списъка.

Неномерирани списъци в Markdown се правят като всеки елемент се постави на нов ред и редът започва с `-` или със `*`.

@RadoslavMilanov Ако промяната ти харесва, можеш да натиснеш зеления бутон "Merge". Това ще я приеме и веднага ще обнови нещата.
